### PR TITLE
13-projectiles-stop-existing

### DIFF
--- a/Common/Projectiles/ProjectileVisibility.cs
+++ b/Common/Projectiles/ProjectileVisibility.cs
@@ -34,8 +34,8 @@ namespace ProjectilesBeGone.Common.Projectiles
             }
 
             if ((Mode == ProjMode.None) ||
-               (Mode == ProjMode.Hostile && !projectile.hostile) ||
-               (Mode == ProjMode.HostileAndYours && !projectile.hostile && projectile.owner != Main.myPlayer)) {
+                (Mode == ProjMode.Hostile && !projectile.hostile) ||
+                (Mode == ProjMode.HostileAndYours && !projectile.hostile && projectile.owner != Main.myPlayer)) {
                 projectile.hide = true;
             }
         }

--- a/Common/Projectiles/ProjectileVisibility.cs
+++ b/Common/Projectiles/ProjectileVisibility.cs
@@ -16,11 +16,20 @@ namespace ProjectilesBeGone.Common.Projectiles
         public static bool BossActive { get; set; } = true;
         public static ProjMode Mode { get; set; } = ProjMode.HostileAndYours;
 
+        private static int? _reviveAuraType;
+        private static bool IsReviveAura(int projectileType)
+        {
+            if (_reviveAuraType is null &&
+                ModLoader.TryGetMod("ReviveMod", out Mod mod) &&
+                mod.TryFind("ReviveAura", out ModProjectile aura)) {
+                _reviveAuraType = aura.Type;
+            }
+            return _reviveAuraType is int auraType && projectileType == auraType;
+        }
+
         public override void AI(Projectile projectile)
         {
-            ModLoader.TryGetMod("ReviveMod", out Mod reviveMod);
-            reviveMod.TryFind("ReviveAura", out ModProjectile reviveAura);
-            if (projectile.type == reviveAura.Type || (BossActive && !Main.CurrentFrameFlags.AnyActiveBossNPC)) {
+            if ((BossActive && !Main.CurrentFrameFlags.AnyActiveBossNPC) || IsReviveAura(projectile.type)) {
                 return;
             }
 

--- a/Common/Projectiles/ProjectileVisibility.cs
+++ b/Common/Projectiles/ProjectileVisibility.cs
@@ -13,8 +13,8 @@ namespace ProjectilesBeGone.Common.Projectiles
             None
         }
 
-        public static bool BossActive { get; set; } = true;
         public static ProjMode Mode { get; set; } = ProjMode.HostileAndYours;
+        public static bool BossActive { get; set; } = true;
 
         private static int? _reviveAuraType;
         private static bool IsReviveAura(int projectileType)
@@ -33,9 +33,9 @@ namespace ProjectilesBeGone.Common.Projectiles
                 return;
             }
 
-            if (Mode == ProjMode.None ||
-               Mode == ProjMode.Hostile && !projectile.hostile ||
-               Mode == ProjMode.HostileAndYours && !projectile.hostile && projectile.owner != Main.myPlayer) {
+            if ((Mode == ProjMode.None) ||
+               (Mode == ProjMode.Hostile && !projectile.hostile) ||
+               (Mode == ProjMode.HostileAndYours && !projectile.hostile && projectile.owner != Main.myPlayer)) {
                 projectile.hide = true;
             }
         }


### PR DESCRIPTION
- Bug was caused by a null reference when the Revive Mod was not enabled
- Fixed with error handling when Revive Mod disabled
- Refactored file